### PR TITLE
Improve webhook diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/components/TaskModal.tsx
+++ b/components/TaskModal.tsx
@@ -77,10 +77,10 @@ const TaskModal: React.FC = () => {
       setTask(prev => ({...prev, customFields: prev.customFields.filter(f => f.id !== id)}))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (task.title.trim()) {
-        saveTask(task as Task);
+      await saveTask(task as Task);
     }
   };
   

--- a/context/TaskContext.tsx
+++ b/context/TaskContext.tsx
@@ -6,7 +6,7 @@ import { postTaskToSheet } from '../services/webhookService';
 
 interface TaskContextType {
   tasks: Task[];
-  saveTask: (task: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => void;
+  saveTask: (task: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => Promise<void>;
   deleteTask: (id: string) => void;
   isModalOpen: boolean;
   currentTask: Task | null;
@@ -43,7 +43,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children, webhookUrl
     setCurrentTask(null);
   }, []);
 
-  const saveTask = useCallback((taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => {
+  const saveTask = useCallback(async (taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => {
     let taskToSave: Task;
 
     if ('id' in taskData) {
@@ -63,7 +63,12 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children, webhookUrl
     }
     
     if (webhookUrl) {
-        postTaskToSheet(webhookUrl, taskToSave);
+      try {
+        await postTaskToSheet(webhookUrl, taskToSave);
+      } catch (error) {
+        // o erro já foi registrado dentro de postTaskToSheet, mas mantemos aqui para rastreabilidade
+        console.error('Erro ao postar tarefa no webhook:', error);
+      }
     }
 
     closeModal();

--- a/services/webhookService.ts
+++ b/services/webhookService.ts
@@ -1,56 +1,49 @@
 
 import { Task } from '../types';
 
-const flattenObject = <T extends object,>(obj: T, prefix = ''): Record<string, any> => {
-  return Object.keys(obj).reduce((acc, k) => {
-    const pre = prefix.length ? prefix + '.' : '';
-    const val = (obj as any)[k];
-    if (val && typeof val === 'object' && !Array.isArray(val)) {
-      Object.assign(acc, flattenObject(val, pre + k));
-    } else if (Array.isArray(val)) {
-        acc[pre + k] = val.join(', ');
-    } else {
-      acc[pre + k] = val;
+// Envia uma tarefa para o webhook do Google Apps Script e registra logs detalhados
+export const postTaskToSheet = async (
+  webhookUrl: string,
+  task: Task,
+): Promise<void> => {
+  const payload: Record<string, any> = {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    priority: task.priority,
+    tags: task.tags.join(', '),
+    timeSpent_seconds: task.timeSpent,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+  };
+
+  task.customFields.forEach((field) => {
+    if (field.key.trim()) {
+      payload[`custom_${field.key.trim().replace(/\s+/g, '_')}`] = field.value;
     }
-    return acc;
-  }, {} as Record<string, any>);
-};
+  });
 
+  console.debug('Enviando tarefa para webhook', { webhookUrl, payload });
 
-export const postTaskToSheet = async (webhookUrl: string, task: Task): Promise<void> => {
-    try {
-        const flattenedTask: Record<string, any> = {
-            id: task.id,
-            title: task.title,
-            description: task.description,
-            status: task.status,
-            priority: task.priority,
-            tags: task.tags.join(', '),
-            timeSpent_seconds: task.timeSpent,
-            createdAt: task.createdAt,
-            updatedAt: task.updatedAt,
-        };
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
 
-        task.customFields.forEach(field => {
-            if(field.key.trim()){
-                flattenedTask[`custom_${field.key.trim().replace(/\s+/g, '_')}`] = field.value;
-            }
-        });
-
-        const response = await fetch(webhookUrl, {
-            method: 'POST',
-            mode: 'no-cors', // The Apps Script webhook doesn't handle CORS preflight requests
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(flattenedTask),
-        });
-        
-        // no-cors mode means we can't read the response, but we can check if it was sent.
-        console.log('Dados da tarefa enviados para o webhook para a tarefa:', task.title);
-
-    } catch (error) {
-        console.error('Falha ao enviar a tarefa para o Google Sheet:', error);
-        // Optionally, show a toast notification to the user about the failure
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      console.error('Resposta inválida do webhook', response.status, text);
+      throw new Error(`Webhook respondeu com status ${response.status}`);
     }
+
+    console.log('Dados da tarefa enviados para o webhook para a tarefa:', task.title);
+  } catch (error) {
+    console.error('Falha ao enviar a tarefa para o Google Sheet:', error);
+    throw error;
+  }
 };


### PR DESCRIPTION
## Summary
- add detailed logging and response validation when posting tasks to Google Sheets
- handle async task saving and propagate webhook errors
- ignore build artifacts and dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68accdb988188324890fc2a5357db687