### PR TITLE
Improve webhook reliability with no-cors fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import { TaskProvider } from './context/TaskContext';
 import SettingsModal from './components/SettingsModal';
 import Header from './components/Header';
 import KanbanBoard from './components/KanbanBoard';
+import LogPanel from './components/LogPanel';
 import { useLocalStorage } from './hooks/useLocalStorage';
 
 const App: React.FC = () => {
@@ -59,6 +60,7 @@ const App: React.FC = () => {
             </div>
           )}
         </main>
+        <LogPanel />
       </div>
     </TaskProvider>
   );

--- a/components/LogPanel.tsx
+++ b/components/LogPanel.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { TaskContext } from '../context/TaskContext';
+
+const LogPanel: React.FC = () => {
+  const { logs } = useContext(TaskContext);
+
+  if (!logs.length) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-black bg-opacity-80 text-green-400 text-xs max-h-40 overflow-y-auto p-2 font-mono z-50">
+      {logs.map((log, index) => (
+        <div key={index} className="whitespace-pre-wrap">{log}</div>
+      ))}
+    </div>
+  );
+};
+
+export default LogPanel;

--- a/components/TaskModal.tsx
+++ b/components/TaskModal.tsx
@@ -77,10 +77,10 @@ const TaskModal: React.FC = () => {
       setTask(prev => ({...prev, customFields: prev.customFields.filter(f => f.id !== id)}))
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (task.title.trim()) {
-        saveTask(task as Task);
+      await saveTask(task as Task);
     }
   };
   

--- a/context/TaskContext.tsx
+++ b/context/TaskContext.tsx
@@ -6,12 +6,14 @@ import { postTaskToSheet } from '../services/webhookService';
 
 interface TaskContextType {
   tasks: Task[];
-  saveTask: (task: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => void;
+  saveTask: (task: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => Promise<void>;
   deleteTask: (id: string) => void;
   isModalOpen: boolean;
   currentTask: Task | null;
   openModal: (task?: Task) => void;
   closeModal: () => void;
+  logs: string[];
+  addLog: (message: string) => void;
 }
 
 export const TaskContext = createContext<TaskContextType>({} as TaskContextType);
@@ -25,6 +27,11 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children, webhookUrl
   const [tasks, setTasks] = useLocalStorage<Task[]>('tasks', []);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [currentTask, setCurrentTask] = useState<Task | null>(null);
+  const [logs, setLogs] = useState<string[]>([]);
+
+  const addLog = useCallback((message: string) => {
+    setLogs(prev => [...prev.slice(-50), `${new Date().toISOString()} - ${message}`]);
+  }, []);
 
   // Clear tasks if webhookUrl is cleared
   useEffect(() => {
@@ -43,7 +50,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children, webhookUrl
     setCurrentTask(null);
   }, []);
 
-  const saveTask = useCallback((taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => {
+  const saveTask = useCallback(async (taskData: Omit<Task, 'id' | 'createdAt' | 'updatedAt'> | Task) => {
     let taskToSave: Task;
 
     if ('id' in taskData) {
@@ -63,11 +70,27 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children, webhookUrl
     }
     
     if (webhookUrl) {
-        postTaskToSheet(webhookUrl, taskToSave);
+      addLog(`Enviando tarefa para webhook (${webhookUrl}): ${taskToSave.title}`);
+      if (typeof navigator !== 'undefined' && !navigator.onLine) {
+        addLog('Aviso: navegador offline, tentativa de envio mesmo assim.');
+      }
+      try {
+        const result = await postTaskToSheet(webhookUrl, taskToSave);
+        addLog(`Webhook respondeu (${result.status}): ${result.body}`);
+      } catch (error: any) {
+        const msg = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+        addLog(`Erro ao enviar tarefa: ${msg}`);
+        if (error instanceof Error && error.stack) {
+          addLog(error.stack);
+        }
+        alert('Falha ao enviar a tarefa para a planilha. Verifique os logs para mais detalhes.');
+      }
+    } else {
+      addLog('Webhook não configurado. Tarefa salva apenas localmente.');
     }
 
     closeModal();
-  }, [setTasks, closeModal, webhookUrl]);
+  }, [setTasks, closeModal, webhookUrl, addLog]);
 
   const deleteTask = useCallback((id: string) => {
     setTasks(prevTasks => prevTasks.filter(t => t.id !== id));
@@ -78,7 +101,7 @@ export const TaskProvider: React.FC<TaskProviderProps> = ({ children, webhookUrl
   }, [setTasks, closeModal]);
 
   return (
-    <TaskContext.Provider value={{ tasks, saveTask, deleteTask, isModalOpen, currentTask, openModal, closeModal }}>
+    <TaskContext.Provider value={{ tasks, saveTask, deleteTask, isModalOpen, currentTask, openModal, closeModal, logs, addLog }}>
       {children}
     </TaskContext.Provider>
   );

--- a/services/webhookService.ts
+++ b/services/webhookService.ts
@@ -1,56 +1,65 @@
 
 import { Task } from '../types';
 
-const flattenObject = <T extends object,>(obj: T, prefix = ''): Record<string, any> => {
-  return Object.keys(obj).reduce((acc, k) => {
-    const pre = prefix.length ? prefix + '.' : '';
-    const val = (obj as any)[k];
-    if (val && typeof val === 'object' && !Array.isArray(val)) {
-      Object.assign(acc, flattenObject(val, pre + k));
-    } else if (Array.isArray(val)) {
-        acc[pre + k] = val.join(', ');
-    } else {
-      acc[pre + k] = val;
+// Envia uma tarefa para o webhook do Google Apps Script e registra logs detalhados
+export const postTaskToSheet = async (
+  webhookUrl: string,
+  task: Task,
+): Promise<{ status: number; body: string }> => {
+  const payload: Record<string, any> = {
+    id: task.id,
+    title: task.title,
+    description: task.description,
+    status: task.status,
+    priority: task.priority,
+    tags: task.tags.join(', '),
+    timeSpent_seconds: task.timeSpent,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+  };
+
+  task.customFields.forEach((field) => {
+    if (field.key.trim()) {
+      payload[`custom_${field.key.trim().replace(/\s+/g, '_')}`] = field.value;
     }
-    return acc;
-  }, {} as Record<string, any>);
-};
+  });
 
+  // Logs para diagnóstico detalhado
+  console.log('[webhook] preparando envio', { webhookUrl, payload });
 
-export const postTaskToSheet = async (webhookUrl: string, task: Task): Promise<void> => {
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const text = await response.text();
+    console.log('[webhook] resposta recebida', {
+      status: response.status,
+      body: text,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} - ${text}`);
+    }
+
+    return { status: response.status, body: text };
+  } catch (error) {
+    console.error('[webhook] falha de rede ao enviar tarefa', error);
+    console.log('[webhook] tentando fallback no-cors');
     try {
-        const flattenedTask: Record<string, any> = {
-            id: task.id,
-            title: task.title,
-            description: task.description,
-            status: task.status,
-            priority: task.priority,
-            tags: task.tags.join(', '),
-            timeSpent_seconds: task.timeSpent,
-            createdAt: task.createdAt,
-            updatedAt: task.updatedAt,
-        };
-
-        task.customFields.forEach(field => {
-            if(field.key.trim()){
-                flattenedTask[`custom_${field.key.trim().replace(/\s+/g, '_')}`] = field.value;
-            }
-        });
-
-        const response = await fetch(webhookUrl, {
-            method: 'POST',
-            mode: 'no-cors', // The Apps Script webhook doesn't handle CORS preflight requests
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(flattenedTask),
-        });
-        
-        // no-cors mode means we can't read the response, but we can check if it was sent.
-        console.log('Dados da tarefa enviados para o webhook para a tarefa:', task.title);
-
-    } catch (error) {
-        console.error('Falha ao enviar a tarefa para o Google Sheet:', error);
-        // Optionally, show a toast notification to the user about the failure
+      await fetch(webhookUrl, {
+        method: 'POST',
+        mode: 'no-cors',
+        body: JSON.stringify(payload),
+      });
+      return { status: 0, body: 'no-cors fallback: resposta indisponível' };
+    } catch (fallbackError) {
+      console.error('[webhook] falha no fallback no-cors', fallbackError);
+      throw fallbackError;
     }
+  }
 };


### PR DESCRIPTION
## Summary
- add no-cors fallback when network requests fail to bypass CORS and still dispatch tasks
- log webhook URL, offline state, and error stack in TaskContext for clearer diagnostics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68accdb988188324890fc2a5357db687