### PR TITLE
Fix fallback request format for Apps Script webhook

### DIFF
--- a/services/webhookService.ts
+++ b/services/webhookService.ts
@@ -47,18 +47,25 @@ export const postTaskToSheet = async (
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status} - ${text}`);
-
     }
 
     return { status: response.status, body: text };
   } catch (error) {
     console.error('[webhook] falha de rede ao enviar tarefa', error);
-    console.log('[webhook] tentando fallback no-cors');
+    console.log('[webhook] tentando fallback no-cors com form-urlencoded');
     try {
+      const formBody = new URLSearchParams();
+      Object.entries(payload).forEach(([key, value]) => {
+        formBody.append(key, String(value));
+      });
+
       await fetch(webhookUrl, {
         method: 'POST',
         mode: 'no-cors',
-        body: JSON.stringify(payload),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: formBody.toString(),
       });
       return { status: 0, body: 'no-cors fallback: resposta indisponível' };
     } catch (fallbackError) {


### PR DESCRIPTION
## Summary
- Use URLSearchParams with `application/x-www-form-urlencoded` in no-cors fallback to ensure Google Apps Script accepts requests
- Log more informative message when falling back

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acd54c96008324b6d90b1cbe270ae7